### PR TITLE
refactor: Remove Alt direct input preference

### DIFF
--- a/app/src/main/java/io/github/lens0021/teogeul/TeogeulKOKR.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/TeogeulKOKR.kt
@@ -152,8 +152,6 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
 
     var mEnableDvorakLayout: Boolean = false
 
-    var mAltDirect: Boolean = false
-
     var mSelectionMode: Boolean = false
     var mSelectionStart: Int = 0
     var mSelectionEnd: Int = 0
@@ -343,11 +341,10 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
 
     private fun inputChar(
         code: Char,
-        direct: Boolean,
     ) {
         var shift = mHardShift
         var mutableCode = code
-        var isDirect = direct
+        var isDirect = false
 
         if (mutableCode.code == 128) {
             mutableCode = if (shift > 0) 0x2c.toChar() else 0x2e.toChar()
@@ -602,7 +599,7 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
             }
 
             val code = processedEvent.getUnicodeChar(mShiftKeyToggle[mHardShift] or mAltKeyToggle[mHardAlt])
-            inputChar(code.toChar(), mHardAlt != 0 && mAltDirect)
+            inputChar(code.toChar())
             mInput = true
 
             if (mHardShift == 1) {
@@ -675,7 +672,6 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
         mStandardJamo = snapshot.systemUseStandardJamo
         mLangKeyAction = snapshot.systemLangKeyPress
         mHardLangKey = KeyStroke.parse(snapshot.systemHardwareLangKeyStroke)
-        mAltDirect = snapshot.hardwareAltDirect
         mEnableDvorakLayout = snapshot.hardwareEnableDvorak
 
         val modeKey =

--- a/app/src/main/java/io/github/lens0021/teogeul/data/SettingsRepository.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/data/SettingsRepository.kt
@@ -20,7 +20,6 @@ object SettingsDefaults {
     const val hardwareUseMoachigi = true
     const val hardwareFullMoachigi = true
     const val hardwareFullMoachigiDelay = 100
-    const val hardwareAltDirect = true
     const val hardwareEnableDvorak = true
     const val systemUseStandardJamo = false
     const val systemLangKeyPress = "switch_next_method"
@@ -35,7 +34,6 @@ object SettingsKeys {
     val hardwareUseMoachigi = booleanPreferencesKey("hardware_use_moachigi")
     val hardwareFullMoachigi = booleanPreferencesKey("hardware_full_moachigi")
     val hardwareFullMoachigiDelay = intPreferencesKey("hardware_full_moachigi_delay")
-    val hardwareAltDirect = booleanPreferencesKey("hardware_alt_direct")
     val hardwareEnableDvorak = booleanPreferencesKey("hardware_enable_dvorak")
     val systemUseStandardJamo = booleanPreferencesKey("system_use_standard_jamo")
     val systemLangKeyPress = stringPreferencesKey("system_action_on_lang_key_press")
@@ -50,7 +48,6 @@ data class SettingsSnapshot(
     val hardwareUseMoachigi: Boolean,
     val hardwareFullMoachigi: Boolean,
     val hardwareFullMoachigiDelay: Int,
-    val hardwareAltDirect: Boolean,
     val hardwareEnableDvorak: Boolean,
     val systemUseStandardJamo: Boolean,
     val systemLangKeyPress: String,
@@ -76,9 +73,6 @@ class SettingsRepository(
 
     val hardwareFullMoachigiDelay: Flow<Int> =
         dataStore.data.map { it[SettingsKeys.hardwareFullMoachigiDelay] ?: SettingsDefaults.hardwareFullMoachigiDelay }
-
-    val hardwareAltDirect: Flow<Boolean> =
-        dataStore.data.map { it[SettingsKeys.hardwareAltDirect] ?: SettingsDefaults.hardwareAltDirect }
 
     val hardwareEnableDvorak: Flow<Boolean> =
         dataStore.data.map { it[SettingsKeys.hardwareEnableDvorak] ?: SettingsDefaults.hardwareEnableDvorak }
@@ -128,7 +122,6 @@ class SettingsRepository(
             hardwareFullMoachigi = prefs[SettingsKeys.hardwareFullMoachigi] ?: SettingsDefaults.hardwareFullMoachigi,
             hardwareFullMoachigiDelay =
                 prefs[SettingsKeys.hardwareFullMoachigiDelay] ?: SettingsDefaults.hardwareFullMoachigiDelay,
-            hardwareAltDirect = prefs[SettingsKeys.hardwareAltDirect] ?: SettingsDefaults.hardwareAltDirect,
             hardwareEnableDvorak = prefs[SettingsKeys.hardwareEnableDvorak] ?: SettingsDefaults.hardwareEnableDvorak,
             systemUseStandardJamo = prefs[SettingsKeys.systemUseStandardJamo] ?: SettingsDefaults.systemUseStandardJamo,
             systemLangKeyPress = prefs[SettingsKeys.systemLangKeyPress] ?: SettingsDefaults.systemLangKeyPress,

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsViewModel.kt
@@ -53,13 +53,6 @@ class SettingsViewModel @Inject constructor(
             SettingsDefaults.hardwareFullMoachigiDelay,
         )
 
-    val hardwareAltDirect: StateFlow<Boolean> =
-        repository.hardwareAltDirect.stateIn(
-            viewModelScope,
-            SharingStarted.WhileSubscribed(5_000),
-            SettingsDefaults.hardwareAltDirect,
-        )
-
     // System preferences
     val systemUseStandardJamo: StateFlow<Boolean> =
         repository.systemUseStandardJamo.stateIn(
@@ -106,7 +99,6 @@ class SettingsViewModel @Inject constructor(
                     when (key) {
                         "hardware_use_moachigi" -> repository.updateBoolean(SettingsKeys.hardwareUseMoachigi, value)
                         "hardware_full_moachigi" -> repository.updateBoolean(SettingsKeys.hardwareFullMoachigi, value)
-                        "hardware_alt_direct" -> repository.updateBoolean(SettingsKeys.hardwareAltDirect, value)
                         "system_use_standard_jamo" -> repository.updateBoolean(SettingsKeys.systemUseStandardJamo, value)
                         else -> Unit
                     }

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/TeogeulSettingsActivity.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/TeogeulSettingsActivity.kt
@@ -208,7 +208,6 @@ fun HardKeyboardScreen(
     val useMoachigi by viewModel.hardwareUseMoachigi.collectAsState()
     val fullMoachigi by viewModel.hardwareFullMoachigi.collectAsState()
     val moachingiDelay by viewModel.hardwareFullMoachingiDelay.collectAsState()
-    val altDirect by viewModel.hardwareAltDirect.collectAsState()
 
     val hangulEntries = stringArrayResource(R.array.keyboard_hangul_layout).toList()
     val hangulValues = stringArrayResource(R.array.keyboard_hangul_layout_id).toList()
@@ -285,15 +284,6 @@ fun HardKeyboardScreen(
                     summary = stringResource(R.string.preference_hardware_full_moachigi_delay_summary),
                     value = moachingiDelay,
                     onValueChange = { viewModel.updatePreference("hardware_full_moachigi_delay", it) },
-                )
-            }
-
-            item {
-                CheckboxPreference(
-                    title = stringResource(R.string.preference_hardware_alt_direct_title),
-                    summary = stringResource(R.string.preference_hardware_alt_direct_summary),
-                    checked = altDirect,
-                    onCheckedChange = { viewModel.updatePreference("hardware_alt_direct", it) },
                 )
             }
         }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -55,9 +55,6 @@
     <string name="preference_hardware_full_moachigi_delay_title">한 번에 모아치기 대기 시간</string>
     <string name="preference_hardware_full_moachigi_delay_summary">한 번에 모아치기 사용 시 조합 종료 대기 시간을 밀리초(ms) 단위로 정합니다. 이 시간 동안 추가 입력이 없으면 입력된 자모들이 한 글자로 조합됩니다. 기본값은 100ms입니다.</string>
 
-    <string name="preference_hardware_alt_direct_title">Alt키로 항상 기호 입력</string>
-    <string name="preference_hardware_alt_direct_summary">하드웨어 Alt키 조합시 기호를 그대로 입력합니다.\n예: Alt+1을 누르면 키에 표시된 기호(! 등)가 그대로 입력됩니다.\n이 옵션을 끄면 한글 모드에서 Alt 키 조합이 한글 자모로 해석될 수 있습니다.</string>
-
     <string name="preference_system_setting_menu">시스템 설정</string>
 
     <string name="preference_system_use_standard_jamo_title">표준 한글 자모 사용</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,10 +86,6 @@
   <string name="preference_hardware_full_moachigi_delay_title">Full Moachigi Timeout</string>
   <string name="preference_hardware_full_moachigi_delay_summary">Set the timeout in milliseconds (ms) for Full Moachigi. If there\'s no additional input during this time, the entered characters will be combined into one character. Default value is 100ms.</string>
 
-    <string name="preference_hardware_alt_direct_title">Alt Direct input</string>
-    <string name="preference_hardware_alt_direct_summary">Always input literal symbols on hardware Alt key combination.\nExample: Alt+1 inputs the symbol (such as !) shown on the key.\nWhen this option is off, Alt key combinations in Korean mode may be interpreted as Korean characters.</string>
-
-
     <string name="preference_system_setting_menu">System Settings</string>
 
     <string name="preference_system_use_standard_jamo_title">Use standard Hangul jamo</string>


### PR DESCRIPTION
## Summary

- Remove "Alt direct input" setting from hardware keyboard preferences UI
- Alt key now uses default system behavior without special handling
- Clean up related code in ViewModel, Repository, and IME engine
- Remove unused parameter from inputChar() function
- Remove string resources for the removed preference

This change simplifies the settings by removing a preference with limited utility. The Alt key will now behave with default system behavior instead of having special handling.

## Changes

### Settings UI
- Removed Alt direct input checkbox from hardware keyboard settings screen

### Data Layer
- Removed `hardwareAltDirect` from `SettingsDefaults`, `SettingsKeys`, and `SettingsSnapshot`
- Removed related Flow and preference update logic from `SettingsRepository`
- Removed `hardwareAltDirect` StateFlow from `SettingsViewModel`

### IME Engine
- Removed `mAltDirect` variable from `TeogeulKOKR`
- Removed unused `direct` parameter from `inputChar()` function
- Changed `inputChar()` signature from `inputChar(code: Char, direct: Boolean)` to `inputChar(code: Char)`
- `isDirect` is now initialized to `false` within the function instead of being passed as parameter

### Resources
- Removed `preference_hardware_alt_direct_title` and `preference_hardware_alt_direct_summary` from both Korean and English string resources

## Test plan

- [x] Code compiles without errors
- [ ] Settings UI displays correctly without the removed option
- [ ] Alt key uses default system behavior
- [ ] No crashes when opening hardware keyboard settings
- [ ] Existing settings are preserved after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)