### PR TITLE
fix: Connect onEvent to processKeyEvent to handle hardware keys

### DIFF
--- a/app/src/main/java/io/github/lens0021/teogeul/TeogeulKOKR.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/TeogeulKOKR.kt
@@ -336,7 +336,10 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
     }
 
     override fun onEvent(ev: TeogeulEvent): Boolean {
-        return false
+        return when (ev) {
+            is InputKeyEvent -> processKeyEvent(ev.keyEvent)
+            else -> false
+        }
     }
 
     private fun inputChar(


### PR DESCRIPTION
The onEvent() method was returning false without processing any events, causing hardware keys like KEYCODE_LANGUAGE_SWITCH (한/영 key) to not work. Now InputKeyEvent is properly forwarded to processKeyEvent() for handling.

Fixes physical keyboard language switch key not working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)