### PR TITLE
feat: Start language mode options for input start

### DIFF
--- a/app/src/main/java/io/github/lens0021/teogeul/TeogeulKOKR.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/TeogeulKOKR.kt
@@ -29,6 +29,7 @@ import io.github.lens0021.teogeul.event.TeogeulEvent
 import io.github.lens0021.teogeul.event.TeogeulEventFlow
 import io.github.lens0021.teogeul.ui.TeogeulSettingsActivity
 import io.github.lens0021.teogeul.data.SettingsRepository
+import io.github.lens0021.teogeul.data.SettingsValues
 import io.github.lens0021.teogeul.data.settingsDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -206,7 +207,7 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
     ) {
         resetCharComposition()
         super.onStartInputView(attribute, restarting)
-        applyPreferences()
+        applyPreferences(resetLanguage = true)
     }
 
     override fun onStartInput(
@@ -214,7 +215,7 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
         restarting: Boolean,
     ) {
         super.onStartInput(attribute, restarting)
-        applyPreferences()
+        applyPreferences(resetLanguage = true)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -667,12 +668,15 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
     fun updateMetaKeyStateDisplay() {
     }
 
-    private fun applyPreferences() {
+    private fun applyPreferences(resetLanguage: Boolean = false) {
         val snapshot = runBlocking { settingsRepository.snapshot() }
         mHardwareMoachigi = snapshot.hardwareUseMoachigi
         mFullMoachigi = snapshot.hardwareFullMoachigi
         mMoachigiDelay = snapshot.hardwareFullMoachigiDelay
         mStandardJamo = snapshot.systemUseStandardJamo
+        if (resetLanguage) {
+            applyStartLanguage(snapshot.systemStartHangulMode)
+        }
         mLangKeyAction = snapshot.systemLangKeyPress
         mHardLangKey = KeyStroke.parse(snapshot.systemHardwareLangKeyStroke)
         mEnableDvorakLayout = snapshot.hardwareEnableDvorak
@@ -684,6 +688,16 @@ class TeogeulKOKR : Teogeul, HangulEngineListener {
                 snapshot.hardwareHangulLayout
             }
         applyEngineMode(EngineMode.get(modeKey))
+    }
+
+    private fun applyStartLanguage(mode: String) {
+        when (mode) {
+            SettingsValues.startHangulModeStartHangul -> mCurrentLanguage = EngineMode.LANG_KO
+            SettingsValues.startHangulModeStartEnglish -> mCurrentLanguage = EngineMode.LANG_EN
+            "new_input",
+            "always",
+            -> mCurrentLanguage = EngineMode.LANG_KO
+        }
     }
 
     private fun applyEngineMode(mode: EngineMode) {

--- a/app/src/main/java/io/github/lens0021/teogeul/data/SettingsRepository.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/data/SettingsRepository.kt
@@ -22,10 +22,17 @@ object SettingsDefaults {
     const val hardwareFullMoachigiDelay = 100
     const val hardwareEnableDvorak = true
     const val systemUseStandardJamo = false
+    const val systemStartHangulMode = SettingsValues.startHangulModeKeepLast
     const val systemLangKeyPress = "switch_next_method"
     const val systemLangKeyLongPress = "list_methods"
     const val systemAltKeyLongPress = "list_actions"
     const val systemHardwareLangKeyStroke = "---s62"
+}
+
+object SettingsValues {
+    const val startHangulModeKeepLast = "keep_last"
+    const val startHangulModeStartHangul = "start_hangul"
+    const val startHangulModeStartEnglish = "start_english"
 }
 
 object SettingsKeys {
@@ -36,6 +43,7 @@ object SettingsKeys {
     val hardwareFullMoachigiDelay = intPreferencesKey("hardware_full_moachigi_delay")
     val hardwareEnableDvorak = booleanPreferencesKey("hardware_enable_dvorak")
     val systemUseStandardJamo = booleanPreferencesKey("system_use_standard_jamo")
+    val systemStartHangulMode = stringPreferencesKey("system_start_hangul_mode")
     val systemLangKeyPress = stringPreferencesKey("system_action_on_lang_key_press")
     val systemLangKeyLongPress = stringPreferencesKey("system_action_on_lang_key_long_press")
     val systemAltKeyLongPress = stringPreferencesKey("system_action_on_alt_key_long_press")
@@ -50,6 +58,7 @@ data class SettingsSnapshot(
     val hardwareFullMoachigiDelay: Int,
     val hardwareEnableDvorak: Boolean,
     val systemUseStandardJamo: Boolean,
+    val systemStartHangulMode: String,
     val systemLangKeyPress: String,
     val systemLangKeyLongPress: String,
     val systemAltKeyLongPress: String,
@@ -79,6 +88,9 @@ class SettingsRepository(
 
     val systemUseStandardJamo: Flow<Boolean> =
         dataStore.data.map { it[SettingsKeys.systemUseStandardJamo] ?: SettingsDefaults.systemUseStandardJamo }
+
+    val systemStartHangulMode: Flow<String> =
+        dataStore.data.map { it[SettingsKeys.systemStartHangulMode] ?: SettingsDefaults.systemStartHangulMode }
 
     val systemLangKeyPress: Flow<String> =
         dataStore.data.map { it[SettingsKeys.systemLangKeyPress] ?: SettingsDefaults.systemLangKeyPress }
@@ -124,6 +136,8 @@ class SettingsRepository(
                 prefs[SettingsKeys.hardwareFullMoachigiDelay] ?: SettingsDefaults.hardwareFullMoachigiDelay,
             hardwareEnableDvorak = prefs[SettingsKeys.hardwareEnableDvorak] ?: SettingsDefaults.hardwareEnableDvorak,
             systemUseStandardJamo = prefs[SettingsKeys.systemUseStandardJamo] ?: SettingsDefaults.systemUseStandardJamo,
+            systemStartHangulMode =
+                prefs[SettingsKeys.systemStartHangulMode] ?: SettingsDefaults.systemStartHangulMode,
             systemLangKeyPress = prefs[SettingsKeys.systemLangKeyPress] ?: SettingsDefaults.systemLangKeyPress,
             systemLangKeyLongPress = prefs[SettingsKeys.systemLangKeyLongPress] ?: SettingsDefaults.systemLangKeyLongPress,
             systemAltKeyLongPress = prefs[SettingsKeys.systemAltKeyLongPress] ?: SettingsDefaults.systemAltKeyLongPress,

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsViewModel.kt
@@ -61,6 +61,13 @@ class SettingsViewModel @Inject constructor(
             SettingsDefaults.systemUseStandardJamo,
         )
 
+    val systemStartHangulMode: StateFlow<String> =
+        repository.systemStartHangulMode.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            SettingsDefaults.systemStartHangulMode,
+        )
+
     val systemLangKeyPress: StateFlow<String> =
         repository.systemLangKeyPress.stateIn(
             viewModelScope,
@@ -106,6 +113,8 @@ class SettingsViewModel @Inject constructor(
                     when (key) {
                         "hardware_hangul_layout" -> repository.updateString(SettingsKeys.hardwareHangulLayout, value)
                         "hardware_alphabet_layout" -> repository.updateString(SettingsKeys.hardwareAlphabetLayout, value)
+                        "system_start_hangul_mode" ->
+                            repository.updateString(SettingsKeys.systemStartHangulMode, value)
                         "system_action_on_lang_key_press" -> repository.updateString(SettingsKeys.systemLangKeyPress, value)
                         "system_action_on_lang_key_long_press" ->
                             repository.updateString(SettingsKeys.systemLangKeyLongPress, value)

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/TeogeulSettingsActivity.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/TeogeulSettingsActivity.kt
@@ -299,6 +299,7 @@ fun SystemScreen(
     viewModel: SettingsViewModel,
 ) {
     val useStandardJamo by viewModel.systemUseStandardJamo.collectAsState()
+    val startHangulMode by viewModel.systemStartHangulMode.collectAsState()
     val langKeyPress by viewModel.systemLangKeyPress.collectAsState()
     val langKeyLongPress by viewModel.systemLangKeyLongPress.collectAsState()
     val altKeyLongPress by viewModel.systemAltKeyLongPress.collectAsState()
@@ -306,6 +307,8 @@ fun SystemScreen(
 
     val langKeyActions = stringArrayResource(R.array.lang_key_actions).toList()
     val langKeyActionsId = stringArrayResource(R.array.lang_key_actions_id).toList()
+    val startHangulEntries = stringArrayResource(R.array.start_hangul_mode_entries).toList()
+    val startHangulValues = stringArrayResource(R.array.start_hangul_mode_values).toList()
 
     Scaffold(
         topBar = {
@@ -337,6 +340,17 @@ fun SystemScreen(
                     summary = stringResource(R.string.preference_system_use_standard_jamo_summary),
                     checked = useStandardJamo,
                     onCheckedChange = { viewModel.updatePreference("system_use_standard_jamo", it) },
+                )
+            }
+
+            item {
+                ListPreference(
+                    title = stringResource(R.string.preference_system_start_hangul_mode_title),
+                    summary = stringResource(R.string.preference_system_start_hangul_mode_summary),
+                    entries = startHangulEntries,
+                    entryValues = startHangulValues,
+                    selectedValue = startHangulMode,
+                    onValueChange = { viewModel.updatePreference("system_start_hangul_mode", it) },
                 )
             }
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -60,6 +60,12 @@
     <string name="preference_system_use_standard_jamo_title">표준 한글 자모 사용</string>
     <string name="preference_system_use_standard_jamo_summary">필요할 경우 표준 한글 자모(유니코드 U+1100-U+11FF 영역)로 첫가끝 한글 조합을 합니다.\n첫가끝 한글 조합: 초성-중성-종성을 분리하여 조합하는 방식입니다. 일부 앱에서 호환성을 위해 필요할 수 있습니다.</string>
 
+    <string name="preference_system_start_hangul_mode_title">시작 언어 모드</string>
+    <string name="preference_system_start_hangul_mode_summary">입력 시작 시 동작을 선택합니다.\n입력 시작: 텍스트 입력 칸에서 터글이 활성화되는 시점(다른 입력기에서 전환하거나 입력창으로 돌아올 때). 기본값: 마지막 언어 유지.</string>
+    <string name="preference_system_start_hangul_mode_start_hangul">입력 시작에 한글 모드로 초기화</string>
+    <string name="preference_system_start_hangul_mode_keep_last">마지막 언어 유지(기본값)</string>
+    <string name="preference_system_start_hangul_mode_start_english">항상 영어로 초기화</string>
+
     <string name="preference_system_lang_key_press_title">언어 키 행동</string>
     <string name="preference_system_lang_key_press_summary">언어 키(한글/영어 모드를 전환하는 특수 키, 일반적으로 \'한/영\' 키)를 누를 때 실행할 행동을 정합니다.</string>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -87,4 +87,16 @@
 	    <item>list_methods</item>
 	    <item>open_settings</item>
     </string-array>
+
+	<string-array name="start_hangul_mode_entries">
+		<item>@string/preference_system_start_hangul_mode_start_hangul</item>
+		<item>@string/preference_system_start_hangul_mode_keep_last</item>
+		<item>@string/preference_system_start_hangul_mode_start_english</item>
+	</string-array>
+
+	<string-array name="start_hangul_mode_values">
+		<item>start_hangul</item>
+		<item>keep_last</item>
+		<item>start_english</item>
+	</string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,12 @@
     <string name="preference_system_use_standard_jamo_title">Use standard Hangul jamo</string>
     <string name="preference_system_use_standard_jamo_summary">Use standard Hangul jamo (Unicode U+1100-U+11FF range) for First-Mid-End Hangul composition when required.\nFirst-Mid-End composition: A method that separates initial, medial, and final consonants. This may be needed for compatibility with some apps.</string>
 
+    <string name="preference_system_start_hangul_mode_title">Start language mode</string>
+    <string name="preference_system_start_hangul_mode_summary">Choose what happens at input start.\nInput start: when Teogeul becomes active for a text field (switching from another IME or returning to a field). Default: Keep last language.</string>
+    <string name="preference_system_start_hangul_mode_start_hangul">Reset to Hangul at input start</string>
+    <string name="preference_system_start_hangul_mode_keep_last">Keep last language (default)</string>
+    <string name="preference_system_start_hangul_mode_start_english">Always reset to English at input start</string>
+
     <string name="preference_system_lang_key_press_title">Action on Language Key Press</string>
     <string name="preference_system_lang_key_press_summary">Choose action to perform on language key press.\nLanguage key: A special key that switches between Korean/English modes, typically the \'한/영\' key on Korean keyboards.</string>
 


### PR DESCRIPTION
> Summary
>
> - 입력 시작 동작 정의를 추가하고 시작 언어 옵션을 3가지로 정리했습니다.
> - 입력 시작 시 한글/영어 초기화 및 마지막 언어 유지 동작을 선택할 수 있게 했습니다.
>
> Testing
>
> - Not run (not requested).
>
> Screenshots
>
> - Not provided (no UI capture).
>
> 🤖 Generated with Codex CLI (https://platform.openai.com/docs/codex)

Co-Authored-By: GPT-5 noreply@openai.com (noreply@openai.com)