### PR TITLE
chore(ci): Speed up PR CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
-        cache-read-only: ${{ github.event_name == 'pull_request' }}
+        cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
@@ -39,6 +39,7 @@ jobs:
         ./gradlew assembleDebug --build-cache --configuration-cache --parallel
 
     - name: Upload APK
+      if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: teogeul-debug
@@ -46,6 +47,7 @@ jobs:
         retention-days: 30
 
     - name: Get APK info
+      if: github.event_name != 'pull_request'
       run: |
         APK_FILE=$(ls app/build/outputs/apk/debug/teogeul-debug-*.apk)
         echo "APK Size: $(du -h $APK_FILE | cut -f1)"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,5 +26,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
       - name: Spotless XML check
         run: ./gradlew spotlessCheck


### PR DESCRIPTION
Summary
- Enable writable Gradle cache on non-fork PRs to improve reuse across PRs
- Skip APK upload/info steps on PR builds to reduce time
- Add Gradle cache setup to Spotless job

Tests
- Not run (CI will run)

> 🤖 Generated with [Codex CLI](https://platform.openai.com/docs/codex)
>
> Co-Authored-By: GPT-5 <noreply@openai.com>