### PR TITLE
fix: Simplify language key toggle

### DIFF
--- a/app/src/main/java/io/github/lens0021/teogeul/config/Settings.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/config/Settings.kt
@@ -14,7 +14,7 @@ object SettingsDefaults {
     const val HARDWARE_ENABLE_DVORAK = true
     const val SYSTEM_USE_STANDARD_JAMO = false
     const val SYSTEM_START_HANGUL_MODE = SettingsValues.START_HANGUL_MODE_KEEP_LAST
-    const val SYSTEM_HARDWARE_LANG_KEY_STROKE = "----218" // KeyEvent.KEYCODE_KANA
+    const val SYSTEM_HARDWARE_LANG_KEY_STROKE = "218" // KeyEvent.KEYCODE_KANA
 }
 
 object SettingsValues {

--- a/app/src/main/java/io/github/lens0021/teogeul/input/KeyEventHandler.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/input/KeyEventHandler.kt
@@ -117,8 +117,8 @@ class KeyEventHandler(
             return false
         }
 
-        // Alt key is not handled by IME - let system handle it for shortcuts
-        if (ev.isAltPressed) {
+        // Alt/Meta key is not handled by IME - let system handle it for shortcuts
+        if (ev.isAltPressed || ev.isMetaPressed) {
             return false
         }
 
@@ -136,18 +136,12 @@ class KeyEventHandler(
         // Handle custom language key combination (e.g., user-defined shortcut for toggling language)
         val hardLangKey = hardLangKeyProvider()
         if (hardLangKey != null && key == hardLangKey.keyCode) {
-            if ((modifierStateManager.hardShift == 1) == hardLangKey.shift &&
-                ev.isAltPressed == hardLangKey.alt &&
-                ev.isCtrlPressed == hardLangKey.control &&
-                ev.isMetaPressed == hardLangKey.win
-            ) {
-                resetCharComposition()
-                toggleLanguage()
-                modifierStateManager.hardShift = 0
-                modifierStateManager.shiftPressing = false
-                updateMetaKeyStateDisplay()
-                return true
-            }
+            resetCharComposition()
+            toggleLanguage()
+            modifierStateManager.hardShift = 0
+            modifierStateManager.shiftPressing = false
+            updateMetaKeyStateDisplay()
+            return true
         }
 
         if (ev.isPrintingKey) {

--- a/app/src/main/java/io/github/lens0021/teogeul/model/KeyStroke.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/model/KeyStroke.kt
@@ -1,32 +1,15 @@
 package io.github.lens0021.teogeul.model
 
 data class KeyStroke(
-    val control: Boolean,
-    val alt: Boolean,
-    val win: Boolean,
-    val shift: Boolean,
     val keyCode: Int,
 ) {
     fun serialize(): String =
-        buildString {
-            append(if (control) 'c' else '-')
-            append(if (alt) 'a' else '-')
-            append(if (win) 'w' else '-')
-            append(if (shift) 's' else '-')
-            append(keyCode)
-        }
+        keyCode.toString()
 
     companion object {
         fun parse(keyStrokeStr: String): KeyStroke {
-            if (keyStrokeStr.length < 5) return KeyStroke(false, false, false, false, 0)
-            val keyCode = keyStrokeStr.substring(4).toIntOrNull() ?: 0
-            return KeyStroke(
-                control = keyStrokeStr[0] == 'c',
-                alt = keyStrokeStr[1] == 'a',
-                win = keyStrokeStr[2] == 'w',
-                shift = keyStrokeStr[3] == 's',
-                keyCode = keyCode,
-            )
+            val keyCode = keyStrokeStr.toIntOrNull() ?: 0
+            return KeyStroke(keyCode)
         }
     }
 }

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/Preferences.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/Preferences.kt
@@ -296,10 +296,6 @@ fun KeystrokePreference(
 
     if (showDialog) {
         val stroke = remember(keystrokeValue) { KeyStroke.parse(keystrokeValue) }
-        var controlChecked by remember { mutableStateOf(stroke.control) }
-        var altChecked by remember { mutableStateOf(stroke.alt) }
-        var winChecked by remember { mutableStateOf(stroke.win) }
-        var shiftChecked by remember { mutableStateOf(stroke.shift) }
         var keyCode by remember { mutableStateOf(stroke.keyCode) }
 
         Dialog(onDismissRequest = { showDialog = false }) {
@@ -321,26 +317,6 @@ fun KeystrokePreference(
                     )
 
                     Spacer(modifier = Modifier.height(16.dp))
-
-                    // Modifier checkboxes
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(checked = controlChecked, onCheckedChange = { controlChecked = it })
-                        Text("Ctrl")
-                    }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(checked = altChecked, onCheckedChange = { altChecked = it })
-                        Text("Alt")
-                    }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(checked = winChecked, onCheckedChange = { winChecked = it })
-                        Text("Win")
-                    }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(checked = shiftChecked, onCheckedChange = { shiftChecked = it })
-                        Text("Shift")
-                    }
-
-                    Spacer(modifier = Modifier.height(8.dp))
 
                     // Key capture view
                     AndroidView(
@@ -374,7 +350,7 @@ fun KeystrokePreference(
                         }
                         TextButton(
                             onClick = {
-                                val newStroke = KeyStroke(controlChecked, altChecked, winChecked, shiftChecked, keyCode)
+                                val newStroke = KeyStroke(keyCode)
                                 onValueChange(newStroke.serialize())
                                 showDialog = false
                             },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,8 +112,7 @@
 	<string name="preference_system_list_actions_title">작업 선택</string>
 
 	<string name="preference_hardware_lang_key_title">하드웨어 키보드 한영 키</string>
-	<string name="preference_hardware_lang_key_summary">하드웨어 키보드 사용시 한영 키를 설정합니다. Shift, Alt 조합을 사용할 수
-		있습니다.</string>
+	<string name="preference_hardware_lang_key_summary">하드웨어 키보드 사용시 한영 키를 설정합니다.</string>
 	<string name="preference_about_license">라이센스</string>
 	<string
 		name="teogeul_korean_license"


### PR DESCRIPTION
## Summary
- switch hardware language key to single-key toggle only
- remove modifier handling and legacy keystroke format\n- update settings UI/strings for single-key behavior

## Testing
- not run (not requested)

🤖 Generated with [Codex CLI](https://platform.openai.com/docs/codex)\n>\n> Co-Authored-By: GPT-5 <noreply@openai.com>