### PR TITLE
fix: remove VIBRATE permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,6 @@
 	android:versionName="23080924">
 	<!-- Version Name: yyMM hhmm -->
 
-	<uses-permission android:name="android.permission.VIBRATE" />
-
 	<application
 		android:name=".Application"
 		android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## Summary
- Remove unused VIBRATE permission from AndroidManifest.xml

## Test plan
- [ ] Build the app successfully
- [ ] Verify no functionality depends on VIBRATE permission

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)