### PR TITLE
feat: Add multiple hardware key mappings support

### DIFF
--- a/app/src/main/java/io/github/lens0021/teogeul/config/Settings.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/config/Settings.kt
@@ -14,7 +14,8 @@ object SettingsDefaults {
     const val HARDWARE_ENABLE_DVORAK = true
     const val SYSTEM_USE_STANDARD_JAMO = false
     const val SYSTEM_START_HANGUL_MODE = SettingsValues.START_HANGUL_MODE_KEEP_LAST
-    const val SYSTEM_HARDWARE_LANG_KEY_STROKE = "218" // KeyEvent.KEYCODE_KANA
+    const val SYSTEM_HARDWARE_LANG_KEY_STROKE = "218" // KeyEvent.KEYCODE_KANA (deprecated)
+    const val SYSTEM_KEY_MAPPINGS = "218|toggle_language" // KANA key -> Toggle Language
 }
 
 object SettingsValues {
@@ -32,7 +33,8 @@ object SettingsKeys {
     val hardwareEnableDvorak = booleanPreferencesKey("hardware_enable_dvorak")
     val systemUseStandardJamo = booleanPreferencesKey("system_use_standard_jamo")
     val systemStartHangulMode = stringPreferencesKey("system_start_hangul_mode")
-    val systemHardwareLangKeyStroke = stringPreferencesKey("system_hardware_lang_key_stroke")
+    val systemHardwareLangKeyStroke = stringPreferencesKey("system_hardware_lang_key_stroke") // deprecated
+    val systemKeyMappings = stringPreferencesKey("system_key_mappings")
 }
 
 data class SettingsSnapshot(
@@ -44,5 +46,6 @@ data class SettingsSnapshot(
     val hardwareEnableDvorak: Boolean,
     val systemUseStandardJamo: Boolean,
     val systemStartHangulMode: String,
-    val systemHardwareLangKeyStroke: String,
+    val systemHardwareLangKeyStroke: String, // deprecated
+    val systemKeyMappings: String,
 )

--- a/app/src/main/java/io/github/lens0021/teogeul/config/SettingsRepository.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/config/SettingsRepository.kt
@@ -64,6 +64,11 @@ class SettingsRepository(
                 ?: SettingsDefaults.SYSTEM_HARDWARE_LANG_KEY_STROKE
         }
 
+    val systemKeyMappings: Flow<String> =
+        dataStore.data.map {
+            it[SettingsKeys.systemKeyMappings] ?: SettingsDefaults.SYSTEM_KEY_MAPPINGS
+        }
+
     suspend fun updateBoolean(
         key: Preferences.Key<Boolean>,
         value: Boolean,
@@ -115,6 +120,9 @@ class SettingsRepository(
             systemHardwareLangKeyStroke =
                 prefs[SettingsKeys.systemHardwareLangKeyStroke]
                     ?: SettingsDefaults.SYSTEM_HARDWARE_LANG_KEY_STROKE,
+            systemKeyMappings =
+                prefs[SettingsKeys.systemKeyMappings]
+                    ?: SettingsDefaults.SYSTEM_KEY_MAPPINGS,
         )
     }
 }

--- a/app/src/main/java/io/github/lens0021/teogeul/input/KeyEventHandler.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/input/KeyEventHandler.kt
@@ -5,7 +5,10 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import io.github.lens0021.teogeul.korean.EngineMode
 import io.github.lens0021.teogeul.korean.HangulEngine
+import io.github.lens0021.teogeul.model.KeyMapping
+import io.github.lens0021.teogeul.model.KeyMappings
 import io.github.lens0021.teogeul.model.KeyStroke
+import io.github.lens0021.teogeul.model.VirtualKeyAction
 
 class KeyEventHandler(
     private val layoutConverter: LayoutConverter,
@@ -13,13 +16,16 @@ class KeyEventHandler(
     private val hangulEngineProvider: () -> HangulEngine,
     private val directInputModeProvider: () -> Boolean,
     private val alphabetLayoutProvider: () -> String,
-    private val hardLangKeyProvider: () -> KeyStroke?,
+    private val hardLangKeyProvider: () -> KeyStroke?, // deprecated, kept for compatibility
+    private val keyMappingsProvider: () -> KeyMappings,
     private val currentLanguageProvider: () -> Int,
     private val toggleLanguage: () -> Unit,
     private val resetCharComposition: () -> Unit,
     private val currentInputEditorInfoProvider: () -> EditorInfo?,
     private val sendDefaultEditorAction: (Boolean) -> Unit,
     private val markInput: () -> Unit,
+    private val sendKeyEvent: (KeyEvent) -> Unit,
+    private val openIMEPicker: () -> Unit,
 ) {
     companion object {
         val SHIFT_CONVERT =
@@ -98,7 +104,38 @@ class KeyEventHandler(
             return false
         }
 
-        // Handle custom language key combination (e.g., user-defined shortcut for toggling language)
+        // Handle custom key mappings
+        val mappings = keyMappingsProvider()
+        val matchedMapping = mappings.mappings.find { it.physicalKey == key }
+        if (matchedMapping != null) {
+            resetCharComposition()
+            when (val action = matchedMapping.virtualAction) {
+                is VirtualKeyAction.ToggleLanguage -> {
+                    toggleLanguage()
+                }
+                is VirtualKeyAction.SendKeyEvent -> {
+                    // Create a new KeyEvent with the mapped key code
+                    val newEvent =
+                        KeyEvent(
+                            ev.downTime,
+                            ev.eventTime,
+                            ev.action,
+                            action.keyCode,
+                            ev.repeatCount,
+                            0, // metaState = 0 (no modifiers)
+                            ev.deviceId,
+                            ev.scanCode,
+                        )
+                    sendKeyEvent(newEvent)
+                }
+                is VirtualKeyAction.OpenIMEPicker -> {
+                    openIMEPicker()
+                }
+            }
+            return true
+        }
+
+        // Handle custom language key combination (deprecated, for backward compatibility)
         val hardLangKey = hardLangKeyProvider()
         if (hardLangKey != null && key == hardLangKey.keyCode) {
             resetCharComposition()

--- a/app/src/main/java/io/github/lens0021/teogeul/input/KeyEventHandler.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/input/KeyEventHandler.kt
@@ -5,7 +5,6 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import io.github.lens0021.teogeul.korean.EngineMode
 import io.github.lens0021.teogeul.korean.HangulEngine
-import io.github.lens0021.teogeul.model.KeyMapping
 import io.github.lens0021.teogeul.model.KeyMappings
 import io.github.lens0021.teogeul.model.KeyStroke
 import io.github.lens0021.teogeul.model.VirtualKeyAction
@@ -79,14 +78,7 @@ class KeyEventHandler(
         }
 
         // Ctrl key handling (available since API 11, always true for minSdk 26)
-        if (ev.isCtrlPressed) {
-            val converted =
-                layoutConverter.convertKeyEventForShortcut(ev, alphabetLayoutProvider())
-            inputConnection.sendKeyEvent(converted ?: ev)
-            return true
-        }
-
-        if (ev.isAltPressed || ev.isMetaPressed) {
+        if (ev.isCtrlPressed || ev.isAltPressed || ev.isMetaPressed) {
             val converted =
                 layoutConverter.convertKeyEventForShortcut(ev, alphabetLayoutProvider())
             inputConnection.sendKeyEvent(converted ?: ev)
@@ -105,11 +97,10 @@ class KeyEventHandler(
         }
 
         // Handle custom key mappings
-        val mappings = keyMappingsProvider()
-        val matchedMapping = mappings.mappings.find { it.physicalKey == key }
-        if (matchedMapping != null) {
+        val action = keyMappingsProvider().mappings.firstOrNull { it.physicalKey == key }?.virtualAction
+        if (action != null) {
             resetCharComposition()
-            when (val action = matchedMapping.virtualAction) {
+            when (action) {
                 is VirtualKeyAction.ToggleLanguage -> {
                     toggleLanguage()
                 }

--- a/app/src/main/java/io/github/lens0021/teogeul/model/KeyMapping.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/model/KeyMapping.kt
@@ -1,0 +1,141 @@
+package io.github.lens0021.teogeul.model
+
+import android.content.Context
+import android.view.KeyEvent
+import io.github.lens0021.teogeul.R
+
+/**
+ * Represents a virtual key action that can be triggered by a physical key.
+ */
+sealed class VirtualKeyAction {
+    /**
+     * Toggle between Korean and English input.
+     */
+    object ToggleLanguage : VirtualKeyAction()
+
+    /**
+     * Send a key event to the system.
+     * @param keyCode The key code to send (e.g., KEYCODE_LANGUAGE_SWITCH)
+     */
+    data class SendKeyEvent(
+        val keyCode: Int,
+    ) : VirtualKeyAction()
+
+    /**
+     * Open the IME picker dialog.
+     */
+    object OpenIMEPicker : VirtualKeyAction()
+
+    /**
+     * Serialize this action to a string for storage.
+     */
+    fun serialize(): String =
+        when (this) {
+            is ToggleLanguage -> "toggle_language"
+            is SendKeyEvent -> "send_key:$keyCode"
+            is OpenIMEPicker -> "open_ime_picker"
+        }
+
+    companion object {
+        /**
+         * Parse a serialized action string back to a VirtualKeyAction.
+         * Returns null if the format is invalid.
+         */
+        fun parse(serialized: String): VirtualKeyAction? =
+            when {
+                serialized == "toggle_language" -> ToggleLanguage
+                serialized.startsWith("send_key:") -> {
+                    val keyCode = serialized.substringAfter("send_key:").toIntOrNull()
+                    keyCode?.let { SendKeyEvent(it) }
+                }
+                serialized == "open_ime_picker" -> OpenIMEPicker
+                else -> null
+            }
+
+        /**
+         * Get a user-friendly display name for the action.
+         */
+        fun getDisplayName(
+            action: VirtualKeyAction,
+            context: Context,
+        ): String =
+            when (action) {
+                is ToggleLanguage -> context.getString(R.string.virtual_key_toggle_language)
+                is SendKeyEvent -> {
+                    if (action.keyCode == KeyEvent.KEYCODE_LANGUAGE_SWITCH) {
+                        context.getString(R.string.virtual_key_language_switch)
+                    } else {
+                        "${context.getString(
+                            R.string.virtual_key_send_key,
+                        )}: ${KeyEvent.keyCodeToString(action.keyCode)}"
+                    }
+                }
+                is OpenIMEPicker -> context.getString(R.string.virtual_key_open_ime_picker)
+            }
+    }
+}
+
+/**
+ * Represents a single key mapping from a physical key to a virtual action.
+ */
+data class KeyMapping(
+    val physicalKey: Int, // KeyEvent.KEYCODE_*
+    val virtualAction: VirtualKeyAction,
+) {
+    /**
+     * Serialize this mapping to a string for storage.
+     * Format: "physicalKey|virtualAction"
+     */
+    fun serialize(): String = "$physicalKey|${virtualAction.serialize()}"
+
+    companion object {
+        /**
+         * Parse a serialized mapping string back to a KeyMapping.
+         * Returns null if the format is invalid.
+         */
+        fun parse(serialized: String): KeyMapping? {
+            val parts = serialized.split("|", limit = 2)
+            if (parts.size != 2) return null
+
+            val physicalKey = parts[0].toIntOrNull() ?: return null
+            val virtualAction = VirtualKeyAction.parse(parts[1]) ?: return null
+
+            return KeyMapping(physicalKey, virtualAction)
+        }
+    }
+}
+
+/**
+ * Container for a list of key mappings.
+ */
+data class KeyMappings(
+    val mappings: List<KeyMapping>,
+) {
+    /**
+     * Serialize all mappings to a string for storage.
+     * Format: "mapping1;mapping2;mapping3"
+     */
+    fun serialize(): String = mappings.joinToString(";") { it.serialize() }
+
+    companion object {
+        /**
+         * Parse a serialized mappings string back to a KeyMappings object.
+         * Invalid mappings are filtered out.
+         */
+        fun parse(serialized: String): KeyMappings {
+            if (serialized.isEmpty()) return EMPTY
+
+            val mappings =
+                serialized
+                    .split(";")
+                    .mapNotNull { KeyMapping.parse(it) }
+
+            return KeyMappings(mappings)
+        }
+
+        /**
+         * Empty mappings (no key mappings configured).
+         */
+        val EMPTY = KeyMappings(emptyList())
+    }
+}

--- a/app/src/main/java/io/github/lens0021/teogeul/model/KeyMapping.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/model/KeyMapping.kt
@@ -4,31 +4,15 @@ import android.content.Context
 import android.view.KeyEvent
 import io.github.lens0021.teogeul.R
 
-/**
- * Represents a virtual key action that can be triggered by a physical key.
- */
 sealed class VirtualKeyAction {
-    /**
-     * Toggle between Korean and English input.
-     */
     object ToggleLanguage : VirtualKeyAction()
 
-    /**
-     * Send a key event to the system.
-     * @param keyCode The key code to send (e.g., KEYCODE_LANGUAGE_SWITCH)
-     */
     data class SendKeyEvent(
         val keyCode: Int,
     ) : VirtualKeyAction()
 
-    /**
-     * Open the IME picker dialog.
-     */
     object OpenIMEPicker : VirtualKeyAction()
 
-    /**
-     * Serialize this action to a string for storage.
-     */
     fun serialize(): String =
         when (this) {
             is ToggleLanguage -> "toggle_language"
@@ -37,10 +21,6 @@ sealed class VirtualKeyAction {
         }
 
     companion object {
-        /**
-         * Parse a serialized action string back to a VirtualKeyAction.
-         * Returns null if the format is invalid.
-         */
         fun parse(serialized: String): VirtualKeyAction? =
             when {
                 serialized == "toggle_language" -> ToggleLanguage
@@ -52,9 +32,6 @@ sealed class VirtualKeyAction {
                 else -> null
             }
 
-        /**
-         * Get a user-friendly display name for the action.
-         */
         fun getDisplayName(
             action: VirtualKeyAction,
             context: Context,
@@ -75,24 +52,13 @@ sealed class VirtualKeyAction {
     }
 }
 
-/**
- * Represents a single key mapping from a physical key to a virtual action.
- */
 data class KeyMapping(
     val physicalKey: Int, // KeyEvent.KEYCODE_*
     val virtualAction: VirtualKeyAction,
 ) {
-    /**
-     * Serialize this mapping to a string for storage.
-     * Format: "physicalKey|virtualAction"
-     */
     fun serialize(): String = "$physicalKey|${virtualAction.serialize()}"
 
     companion object {
-        /**
-         * Parse a serialized mapping string back to a KeyMapping.
-         * Returns null if the format is invalid.
-         */
         fun parse(serialized: String): KeyMapping? {
             val parts = serialized.split("|", limit = 2)
             if (parts.size != 2) return null
@@ -105,23 +71,12 @@ data class KeyMapping(
     }
 }
 
-/**
- * Container for a list of key mappings.
- */
 data class KeyMappings(
     val mappings: List<KeyMapping>,
 ) {
-    /**
-     * Serialize all mappings to a string for storage.
-     * Format: "mapping1;mapping2;mapping3"
-     */
     fun serialize(): String = mappings.joinToString(";") { it.serialize() }
 
     companion object {
-        /**
-         * Parse a serialized mappings string back to a KeyMappings object.
-         * Invalid mappings are filtered out.
-         */
         fun parse(serialized: String): KeyMappings {
             if (serialized.isEmpty()) return EMPTY
 
@@ -133,9 +88,6 @@ data class KeyMappings(
             return KeyMappings(mappings)
         }
 
-        /**
-         * Empty mappings (no key mappings configured).
-         */
         val EMPTY = KeyMappings(emptyList())
     }
 }

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsActivity.kt
@@ -27,6 +27,7 @@ import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import io.github.lens0021.teogeul.IMEService
 import io.github.lens0021.teogeul.R
+import io.github.lens0021.teogeul.model.KeyMappings
 
 @AndroidEntryPoint
 class SettingsActivity : ComponentActivity() {
@@ -80,7 +81,7 @@ fun SettingsMainScreen(
     val moachingiDelay by viewModel.hardwareFullMoachingiDelay.collectAsState()
     val useStandardJamo by viewModel.systemUseStandardJamo.collectAsState()
     val startHangulMode by viewModel.systemStartHangulMode.collectAsState()
-    val hardwareLangKeyStroke by viewModel.systemHardwareLangKeyStroke.collectAsState()
+    val keyMappingsString by viewModel.systemKeyMappings.collectAsState()
 
     val hardwareHangulEntries = stringArrayResource(R.array.keyboard_hangul_layout).toList()
     val hardwareHangulValues = stringArrayResource(R.array.keyboard_hangul_layout_id).toList()
@@ -178,11 +179,20 @@ fun SettingsMainScreen(
         }
 
         item {
-            KeystrokePreference(
-                title = stringResource(R.string.preference_hardware_lang_key_title),
-                summary = stringResource(R.string.preference_hardware_lang_key_summary),
-                keystrokeValue = hardwareLangKeyStroke,
-                onValueChange = { viewModel.updatePreference("system_hardware_lang_key_stroke", it) },
+            val keyMappings =
+                remember(keyMappingsString) {
+                    KeyMappings.parse(keyMappingsString)
+                }
+
+            KeyMappingsPreference(
+                title = stringResource(R.string.preference_key_mappings_title),
+                mappings = keyMappings.mappings,
+                onMappingsChange = { newMappings ->
+                    viewModel.updatePreference(
+                        "system_key_mappings",
+                        KeyMappings(newMappings).serialize(),
+                    )
+                },
             )
         }
 

--- a/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/lens0021/teogeul/ui/SettingsViewModel.kt
@@ -76,6 +76,13 @@ class SettingsViewModel
                 SettingsDefaults.SYSTEM_HARDWARE_LANG_KEY_STROKE,
             )
 
+        val systemKeyMappings: StateFlow<String> =
+            repository.systemKeyMappings.stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5_000),
+                SettingsDefaults.SYSTEM_KEY_MAPPINGS,
+            )
+
         fun updatePreference(
             key: String,
             value: Any,
@@ -113,6 +120,8 @@ class SettingsViewModel
                                 repository.updateString(SettingsKeys.systemStartHangulMode, value)
                             "system_hardware_lang_key_stroke" ->
                                 repository.updateString(SettingsKeys.systemHardwareLangKeyStroke, value)
+                            "system_key_mappings" ->
+                                repository.updateString(SettingsKeys.systemKeyMappings, value)
                             else -> Unit
                         }
                     is Int ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,24 @@
 	<string name="preference_hardware_lang_key_title">하드웨어 키보드 한영 키</string>
 	<string name="preference_hardware_lang_key_summary">하드웨어 키보드 사용시 한영 키를 설정합니다.</string>
 
+	<!-- Key Mappings -->
+	<string name="preference_key_mappings_title">하드웨어 키 매핑</string>
+	<string name="key_mappings_empty">매핑이 없습니다. 추가 버튼을 눌러 새 매핑을 만드세요.</string>
+	<string name="key_mappings_add">새 항목 추가</string>
+	<string name="key_mapping_dialog_title">키 매핑 추가</string>
+	<string name="key_mapping_physical_key">물리 키</string>
+	<string name="key_mapping_press_key">키를 눌러주세요</string>
+	<string name="key_mapping_virtual_action">가상 키/동작</string>
+	<string name="key_mapping_use_dropdown">목록에서 선택</string>
+	<string name="key_mapping_select_action">동작을 선택하세요</string>
+	<string name="key_mapping_press_virtual_key">가상 키를 눌러주세요</string>
+
+	<!-- Virtual Key Actions -->
+	<string name="virtual_key_toggle_language">한영 키</string>
+	<string name="virtual_key_language_switch">언어 키 (LANGUAGE_SWITCH)</string>
+	<string name="virtual_key_open_ime_picker">입력기 선택창 열기</string>
+	<string name="virtual_key_send_key">키 전송</string>
+
 	<!-- System Settings -->
 	<string name="preference_system_use_standard_jamo_title">표준 한글 자모 사용</string>
 	<string name="preference_system_use_standard_jamo_summary">필요할 경우 표준 한글 자모(유니코드 U+1100-U+11FF 영역)로 첫가끝 한글 조합을 합니다.\n첫가끝 한글 조합: 초성-중성-종성을 분리하여 조합하는 방식입니다. 일부 앱에서 호환성을 위해 필요할 수 있습니다.</string>

--- a/app/src/test/java/io/github/lens0021/teogeul/input/KeyEventHandlerTest.kt
+++ b/app/src/test/java/io/github/lens0021/teogeul/input/KeyEventHandlerTest.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.inputmethod.BaseInputConnection
 import io.github.lens0021.teogeul.korean.EngineMode
 import io.github.lens0021.teogeul.korean.HangulEngine
+import io.github.lens0021.teogeul.model.KeyMappings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -231,11 +232,14 @@ class KeyEventHandlerTest {
             directInputModeProvider = { false },
             alphabetLayoutProvider = { "keyboard_alphabet_dvorak" },
             hardLangKeyProvider = { null },
+            keyMappingsProvider = { KeyMappings.EMPTY },
             currentLanguageProvider = { EngineMode.LANG_EN },
             toggleLanguage = {},
             resetCharComposition = { hangulEngine.resetComposition() },
             currentInputEditorInfoProvider = { null },
             sendDefaultEditorAction = {},
             markInput = {},
+            sendKeyEvent = { inputConnection.sendKeyEvent(it) },
+            openIMEPicker = {},
         )
 }


### PR DESCRIPTION
## Summary
Extends the single hardware keyboard key mapping feature to support multiple key mappings with different virtual actions.

## Features
- ✅ Support multiple (physical key → virtual action) mapping pairs
- ✅ Predefined virtual actions:
  - **한영 키** (Toggle Language): Internal language toggle between Korean/English
  - **언어 키** (Language Key): Send KEYCODE_LANGUAGE_SWITCH to system
  - **입력기 선택창 열기** (Open IME Picker): Open input method picker
- ✅ UI with "새 항목 추가" (Add new item) button
- ✅ Support both dropdown selection and direct key input
- ✅ Default mapping: KANA key (218) → Toggle Language
- ✅ Add/remove mappings through settings UI

## Technical Implementation

### Data Model
- Created `KeyMapping.kt` with:
  - `VirtualKeyAction` sealed class for type-safe action handling
  - `KeyMapping` data class for individual mappings
  - `KeyMappings` container with string serialization
  - Format: `"physicalKey|action"` separated by semicolons

### Business Logic
- Updated `KeyEventHandler.kt` to process multiple mappings
- Updated `IMEService.kt` to load and apply mappings
- Modified settings storage in `Settings.kt` and `SettingsRepository.kt`

### UI Components
- Added `KeyMappingsPreference` composable for displaying/managing mappings
- Added `KeyMappingDialog` with physical key capture and virtual action selection
- Updated `SettingsViewModel.kt` and `SettingsActivity.kt`

## Files Changed
- **New**: `app/src/main/java/io/github/lens0021/teogeul/model/KeyMapping.kt` (+129 lines)
- **Modified**: 8 files (+540 insertions, -13 deletions)

## Test Plan
- [x] Build successful with no errors or warnings
- [x] Code formatted with Spotless
- [ ] Manual testing: Add/remove key mappings in settings UI
- [ ] Manual testing: Verify KANA key toggles language by default
- [ ] Manual testing: Test all virtual action types with hardware keyboard
- [ ] Manual testing: Verify dropdown and direct key input modes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)